### PR TITLE
Speed up algorithm by fixing type stability

### DIFF
--- a/src/Levenshtein.jl
+++ b/src/Levenshtein.jl
@@ -12,7 +12,8 @@ function levenshtein(source::String, target::String, cost::Real)
     return levenshtein(source, target, cost, cost, cost)
 end
 
-function levenshtein(source::String, target::String, deletion_cost::Real, insertion_cost::Real, substitution_cost::Real)
+function levenshtein{R<:Real,S<:Real,T<:Real}(source::String, target::String, deletion_cost::R, insertion_cost::S, substitution_cost::T)
+    cost_type = promote_type(R,S,T)
     if length(source) < length(target)
         # Space complexity of function = O(length(target))
         return levenshtein(target, source, insertion_cost, deletion_cost, substitution_cost)
@@ -22,8 +23,8 @@ function levenshtein(source::String, target::String, deletion_cost::Real, insert
         elseif length(target) == 0
             return length(source) * deletion_cost
         else
-            local oldRow::Array{Real, 1} = zeros(Real, length(target) + 1)
-            local newRow::Array{Real, 1} = zeros(Real, length(target) + 1)
+            oldRow = zeros(cost_type, length(target) + 1)
+            newRow = zeros(cost_type, length(target) + 1)
 
             # Initialize the old row for empty source and i characters in target
             oldRow[1] = 0
@@ -42,9 +43,9 @@ function levenshtein(source::String, target::String, deletion_cost::Real, insert
                 for c in target 
                     j += 1
 
-                    local deletion::Real = oldRow[j + 1] + deletion_cost
-                    local insertion::Real = newRow[j] + insertion_cost
-                    local substitution::Real = oldRow[j] + (r == c ? 0 : substitution_cost)
+                    deletion = oldRow[j + 1] + deletion_cost
+                    insertion = newRow[j] + insertion_cost
+                    substitution = oldRow[j] + (r == c ? 0 : substitution_cost)
 
                     newRow[j + 1] = min(deletion, insertion, substitution)
                 end


### PR DESCRIPTION
Before
```
IAINMAC:test idunning$ jl runtests.jl
elapsed time: 0.235095972 seconds (36611688 bytes allocated, 16.01% gc time)
```

After
```
IAINMAC:test idunning$ jl runtests.jl
elapsed time: 0.013036577 seconds (9155016 bytes allocated)
```

For
```julia
srand(1234)
N = 1000
s = randString(ifloor(rand() * N))
t = randString(ifloor(rand() * N))
ins, del, sub = rand() * 1000, rand() * 1000, rand() * 1000
@time levenshtein(s, t, del, ins, sub)
```