### PR TITLE
Merge 0.6 dep warning fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
-  - 0.4
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Levenshtein
 
-[![Build Status](https://travis-ci.org/rawrgrr/Levenshtein.jl.svg?branch=master)](https://travis-ci.org/rawrgrr/Levenshtein.jl)
-[![Coverage Status](https://coveralls.io/repos/rawrgrr/Levenshtein.jl/badge.svg?branch=master)](https://coveralls.io/r/rawrgrr/Levenshtein.jl)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rawrgrr/Levenshtein.jl/master/LICENSE.md)
+[![Build Status](https://travis-ci.org/venkr/Levenshtein.jl.svg?branch=master)](https://travis-ci.org/venkr/Levenshtein.jl)
+[![Coverage Status](https://coveralls.io/repos/venkr/Levenshtein.jl/badge.svg?branch=master)](https://coveralls.io/r/venkr/Levenshtein.jl)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/venkr/Levenshtein.jl/master/LICENSE.md)
 
 
 Levenshtein distance between two strings in [julia](http://julialang.org/)

--- a/src/Levenshtein.jl
+++ b/src/Levenshtein.jl
@@ -27,7 +27,7 @@ function levenshtein!{R<:Real,S<:Real,T<:Real}(
     deletion_cost::R,
     insertion_cost::S,
     substitution_cost::T,
-    costs::Matrix = Array(promote_type(R, S, T), 2, length(target) + 1)
+    costs::Matrix = Array{promote_type(R, S, T)}( 2, length(target) + 1)
 )
     cost_type = promote_type(R,S,T)
     if length(source) < length(target)


### PR DESCRIPTION
The minor deprecation warning due to 0.6 has been fixed!

(Note: I changed the README.md badges to check build status, you will need to change it back)