### PR TITLE
Require Julia 1.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6
+julia 1.0


### PR DESCRIPTION
I didn't know the syntax to enable the ability for the package to install on both 0.6* and 1.0*

Just thought I would show that this does correctly install on 1.0 and only the REQUIREMENTS file needs changing.

Here is a screenshot of the current stable version of the package on Julia 1.0 **failing**, and then the version with my amendment **passing**

![screencapture-galaxy-hivdv-uct-ac-za-8010-notebooks-test_levenshtein-ipynb-2018-10-26-10_00_00](https://user-images.githubusercontent.com/3307753/47553162-a240ff80-d906-11e8-8d51-cc929436e239.png)

Merging this would solve #16 but might break current 0.6 installation. Not sure what needs to be done to support both. I have never worked with Julia in a substantial way before.